### PR TITLE
Add types reference for Typescript compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Helper library for using TypeScript with Azure Functions",
   "main": "src/index.js",
+  "typings": "src/index.d.ts",
   "scripts": {
     "pre-build": "typings install",
     "build": "tsc",


### PR DESCRIPTION
Added types reference in package.json in order for the typescript compiler to automatically find the module.